### PR TITLE
During opencontrail attach vifs the containers use dhclient to lease an ...

### DIFF
--- a/etc/nova/rootwrap.d/docker.filters
+++ b/etc/nova/rootwrap.d/docker.filters
@@ -4,3 +4,6 @@
 [Filters]
 # nova/virt/docker/driver.py: 'ln', '-sf', '/var/run/netns/.*'
 ln: CommandFilter, /bin/ln, root
+
+# nova/virt/docker/opencontrail.py: 'rm', '/var/lib/*/dhclient.ns*.leases'
+rm: CommandFilter, /bin/rm, root

--- a/novadocker/virt/docker/opencontrail.py
+++ b/novadocker/virt/docker/opencontrail.py
@@ -12,6 +12,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
+import platform
+
 from nova import utils
 from nova.i18n import _
 from nova.network import linux_net
@@ -25,6 +28,9 @@ LOG = logging.getLogger(__name__)
 class OpenContrailVIFDriver(object):
     def __init__(self):
         self._vrouter_client = ContrailVRouterApi(doconnect=True)
+        self.dhcp_lease_database_dir = '/var/lib/dhclient/'
+        if platform.linux_distribution()[0] == 'Ubuntu':
+            self.dhcp_lease_database_dir = '/var/lib/dhcp/'
 
     def plug(self, instance, vif):
         if_local_name = 'veth%s' % vif['id'][:8]
@@ -96,8 +102,10 @@ class OpenContrailVIFDriver(object):
 
         # TODO(NetNS): attempt DHCP client; fallback to manual config if the
         # container doesn't have an working dhcpclient
+        lease_file = '%s/dhclient.%s.leases' % (self.dhcp_lease_database_dir,
+                                                if_remote_name)
         utils.execute('ip', 'netns', 'exec', container_id, 'dhclient',
-                      if_remote_name, run_as_root=True)
+                      '-lf', lease_file, if_remote_name, run_as_root=True)
 
     def unplug(self, instance, vif):
         try:
@@ -106,4 +114,8 @@ class OpenContrailVIFDriver(object):
             LOG.exception(_("Delete port failed"), instance=instance)
 
         if_local_name = 'veth%s' % vif['id'][:8]
+        if_remote_name = 'ns%s' % vif['id'][:8]
+        lease_file = '%s/dhclient.%s.leases' % (self.dhcp_lease_database_dir,
+                                                if_remote_name)
         utils.execute('ip', 'link', 'delete', if_local_name, run_as_root=True)
+        utils.execute('rm', lease_file, run_as_root=True)


### PR DESCRIPTION
...ip address.

When bulk container create request is sent, the /var/lib/dhcp/dhclient.leases file is overwritten.
Due to the corrupted file Successive docker containers are not getting IP lease
as the dhclient command is failling .

Fixing it by creating separate lease files for each docker container.

Closes-Bug: 1446929
(cherry picked from commit 8256fdf4cbe6b1a1992ac3921bffac95d60cf673)
