### PR TITLE
Removing veth interfaces if the contrainer launch failed

### DIFF
--- a/etc/nova/rootwrap.d/docker.filters
+++ b/etc/nova/rootwrap.d/docker.filters
@@ -4,6 +4,3 @@
 [Filters]
 # nova/virt/docker/driver.py: 'ln', '-sf', '/var/run/netns/.*'
 ln: CommandFilter, /bin/ln, root
-
-# nova/virt/docker/opencontrail.py: 'rm', '/var/lib/*/dhclient.ns*.leases'
-rm: CommandFilter, /bin/rm, root

--- a/novadocker/tests/virt/docker/test_opencontrail.py
+++ b/novadocker/tests/virt/docker/test_opencontrail.py
@@ -1,0 +1,163 @@
+# Copyright (C) 2014 Juniper Networks, Inc
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import mock
+import sys
+
+
+class MockContrailVRouterApi(mock.MagicMock):
+    def __init__(self, *a, **kw):
+        super(MockContrailVRouterApi, self).__init__()
+        self._args = a
+        self._dict = kw
+        self._vifs = {}
+
+    def add_port(self, vm_uuid_str, vif_uuid_str, interface_name,
+                 mac_address, **kwargs):
+        if vm_uuid_str not in self._vifs:
+            self._vifs[vif_uuid_str] = dict(vm=vm_uuid_str,
+                                            intf=interface_name,
+                                            mac=mac_address)
+            self._vifs[vm_uuid_str].update(kwargs)
+            return self._vifs[vif_uuid_str]
+
+    def delete_port(self, vif_uuid_str):
+        if vif_uuid_str in self._vifs:
+            del self._vifs[vif_uuid_str]
+
+
+mock_pkg = mock.MagicMock(name='mock_contrail_vrouter_api')
+mock_mod = mock.MagicMock(name='mock_vrouter_api')
+mock_cls = mock.MagicMock(name='MockOpenContrailVIFDriver',
+                          side_effect=MockContrailVRouterApi)
+mock_mod.OpenContrailVIFDriver = mock_cls
+mock_pkg.vrouter_api = mock_mod
+
+sys.modules['contrail_vrouter_api'] = mock_pkg
+sys.modules['contrail_vrouter_api.vrouter_api'] = mock_mod
+
+from nova.network import model as network_model
+from nova import test
+from novadocker.virt.docker import driver as docker_driver
+
+
+class DockerOpenContrailVIFDriverTestCase(test.TestCase):
+    def setUp(self):
+        super(DockerOpenContrailVIFDriverTestCase, self).setUp()
+        docker_driver.CONF.set_override(
+            'vif_driver',
+            'novadocker.virt.docker.opencontrail.OpenContrailVIFDriver',
+            group='docker')
+
+    def test_plug_vrouter(self):
+        vid = '920be1f4-2b98-411e-890a-69bcabb2a5a0'
+        address = '10.1.2.1'
+        calls = [
+            mock.call('ip', 'link', 'add', 'veth%s' % vid[:8],
+                      'type', 'veth', 'peer', 'name',
+                      'ns%s' % vid[:8], run_as_root=True),
+            mock.call('ip', 'link', 'set', 'ns%s' % vid[:8],
+                      'address', address, run_as_root=True),
+        ]
+        network_info = [network_model.VIF(id=vid, address=address)]
+        with mock.patch('nova.utils.execute') as ex:
+            driver = docker_driver.DockerDriver(object)
+            driver.plug_vifs({'name': 'fake_instance'}, network_info)
+            ex.assert_has_calls(calls)
+
+    def test_plug_two_vrouters(self):
+        vid1 = '921be2f4-2b98-411e-890a-69bcabb2a5a1'
+        address1 = '10.1.2.2'
+        vid2 = '922be3f4-2b98-411e-890a-69bcabb2a5a2'
+        address2 = '10.1.2.3'
+        calls = [
+            mock.call('ip', 'link', 'add', 'veth%s' % vid1[:8],
+                      'type', 'veth', 'peer', 'name',
+                      'ns%s' % vid1[:8], run_as_root=True),
+            mock.call('ip', 'link', 'set', 'ns%s' % vid1[:8],
+                      'address', address1, run_as_root=True),
+            mock.call('ip', 'link', 'add', 'veth%s' % vid2[:8],
+                      'type', 'veth', 'peer', 'name',
+                      'ns%s' % vid2[:8], run_as_root=True),
+            mock.call('ip', 'link', 'set', 'ns%s' % vid2[:8],
+                      'address', address2, run_as_root=True),
+        ]
+        network_info = [network_model.VIF(id=vid1, address=address1),
+                        network_model.VIF(id=vid2, address=address2)]
+        with mock.patch('nova.utils.execute') as ex:
+            driver = docker_driver.DockerDriver(object)
+            driver.plug_vifs({'name': 'fake_instance'}, network_info)
+            ex.assert_has_calls(calls)
+
+    @mock.patch.object(docker_driver.DockerDriver,
+                       '_find_container_by_name',
+                       return_value={'id': 'my_vm'})
+    @mock.patch.object(docker_driver.DockerDriver,
+                       '_find_container_pid',
+                       return_value=7890)
+    def test_attach_vrouter(self, mock_find_by_name, mock_find_pid):
+        vid = '920be1f5-2b98-411e-890a-69bcabb2a5a0'
+        if_remote_name = 'ns%s' % vid[:8]
+        if_local_name = 'veth%s' % vid[:8]
+        address = '10.1.2.1'
+        gateway = '1.1.1.254'
+        fixed_ip = '1.1.1.42/24'
+        calls = [
+            mock.call('mkdir', '-p', '/var/run/netns', run_as_root=True),
+            mock.call('ln', '-sf', '/proc/7890/ns/net',
+                      '/var/run/netns/my_vm', run_as_root=True),
+            mock.call('ip', 'link', 'set', if_remote_name, 'netns', 'my_vm',
+                      run_as_root=True),
+            mock.call('ip', 'link', 'set', if_local_name, 'up',
+                      run_as_root=True),
+            mock.call('ip', 'netns', 'exec', 'my_vm', 'ip', 'link',
+                      'set', if_remote_name, 'address', address,
+                      run_as_root=True),
+            mock.call('ip', 'netns', 'exec', 'my_vm', 'ifconfig',
+                      if_remote_name, fixed_ip, run_as_root=True),
+            mock.call('ip', 'netns', 'exec', 'my_vm', 'ip',
+                      'route', 'replace', 'default', 'via', gateway,
+                      'dev', if_remote_name, run_as_root=True),
+            mock.call('ip', 'netns', 'exec', 'my_vm', 'ip', 'link',
+                      'set', if_remote_name, 'up', run_as_root=True)
+        ]
+        network_info = [network_model.VIF(id=vid, address=address,
+                                          network=network_model.Network(
+                                              id='virtual-network-1',
+                                              subnets=[network_model.Subnet(
+                                                  cidr='1.1.1.0/24',
+                                                  gateway=network_model.IP(
+                                                      address=gateway,
+                                                      type='gateway'),
+                                                  ips=[network_model.IP(
+                                                      address='1.1.1.42',
+                                                      type='fixed',
+                                                      version=4)]
+                                              )]
+                                          ))]
+        instance = dict(name='fake_instance', display_name='fake_vm',
+                        hostname='fake_vm', host='linux',
+                        project_id='e2d2ddc6-4e0f-4cd4-b846-3bad53093ec6',
+                        uuid='d4b817fb-7885-4649-bad7-89302dde12e1')
+        with mock.patch('nova.utils.execute') as ex:
+            driver = docker_driver.DockerDriver(object)
+            driver._attach_vifs(instance, network_info)
+            ex.assert_has_calls(calls)
+
+    def test_unplug_vrouter(self):
+        vid = '920be1f4-2b98-411e-890a-69bcabb2a5a0'
+        address = '10.1.2.1'
+        network_info = [network_model.VIF(id=vid, address=address)]
+        driver = docker_driver.DockerDriver(object)
+        driver.unplug_vifs({'name': 'fake_instance'}, network_info)

--- a/novadocker/virt/docker/opencontrail.py
+++ b/novadocker/virt/docker/opencontrail.py
@@ -13,26 +13,40 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import platform
-
-from nova import utils
-from nova.network import linux_net
-from nova.openstack.common import log as logging
-from nova.openstack.common.gettextutils import _
+import eventlet
 
 from contrail_vrouter_api.vrouter_api import ContrailVRouterApi
+
+from nova.network import linux_net
+from nova.openstack.common import loopingcall
+from nova.openstack.common import log as logging
+from nova.openstack.common.gettextutils import _
+from nova import utils
+
+from novadocker.virt.docker import network
 
 LOG = logging.getLogger(__name__)
 
 
 class OpenContrailVIFDriver(object):
     def __init__(self):
-        self._vrouter_client = ContrailVRouterApi(doconnect=True)
-        self.dhcp_lease_database_dir = '/var/lib/dhclient/'
-        if platform.linux_distribution()[0] == 'Ubuntu':
-            self.dhcp_lease_database_dir = '/var/lib/dhcp/'
+        self._vrouter_semaphore = eventlet.semaphore.Semaphore()
+        self._vrouter_client = ContrailVRouterApi(
+            doconnect=True, semaphore=self._vrouter_semaphore)
+        timer = loopingcall.FixedIntervalLoopingCall(self._keep_alive)
+        timer.start(interval=2)
+
+    def _keep_alive(self):
+        self._vrouter_client.periodic_connection_check()
 
     def plug(self, instance, vif):
+        vif_type = vif['type']
+
+        LOG.debug('Plug vif_type=%(vif_type)s instance=%(instance)s '
+                  'vif=%(vif)s',
+                  {'vif_type': vif_type, 'instance': instance,
+                   'vif': vif})
+
         if_local_name = 'veth%s' % vif['id'][:8]
         if_remote_name = 'ns%s' % vif['id'][:8]
 
@@ -56,6 +70,13 @@ class OpenContrailVIFDriver(object):
             undo_mgr.rollback_and_reraise(msg=msg, instance=instance)
 
     def attach(self, instance, vif, container_id):
+        vif_type = vif['type']
+
+        LOG.debug('Attach vif_type=%(vif_type)s instance=%(instance)s '
+                  'vif=%(vif)s',
+                  {'vif_type': vif_type, 'instance': instance,
+                   'vif': vif})
+
         if_local_name = 'veth%s' % vif['id'][:8]
         if_remote_name = 'ns%s' % vif['id'][:8]
 
@@ -102,22 +123,39 @@ class OpenContrailVIFDriver(object):
             msg = _('Failed to attach the network, rolling back')
             undo_mgr.rollback_and_reraise(msg=msg, instance=instance)
 
-        # TODO(NetNS): attempt DHCP client; fallback to manual config if the
-        # container doesn't have an working dhcpclient
-        lease_file = '%s/dhclient.%s.leases' % (self.dhcp_lease_database_dir,
-                                                if_remote_name)
-        utils.execute('ip', 'netns', 'exec', container_id, 'dhclient',
-                      '-lf', lease_file, if_remote_name, run_as_root=True)
+        try:
+            ip = network.find_fixed_ip(instance, vif['network'])
+            gateway = network.find_gateway(instance, vif['network'])
+            utils.execute('ip', 'netns', 'exec', container_id, 'ip', 'link',
+                          'set', if_remote_name, 'address', vif['address'],
+                          run_as_root=True)
+            if ipv6_address:
+                utils.execute('ip', 'netns', 'exec', container_id, 'ifconfig',
+                              if_remote_name, 'inet6', 'add', ip,
+                              run_as_root=True)
+                utils.execute('ip', 'netns', 'exec', container_id, 'ip', '-6',
+                              'route', 'replace', 'default', 'via', gateway,
+                              'dev', if_remote_name, run_as_root=True)
+            else:
+                utils.execute('ip', 'netns', 'exec', container_id, 'ifconfig',
+                              if_remote_name, ip, run_as_root=True)
+                utils.execute('ip', 'netns', 'exec', container_id, 'ip',
+                              'route', 'replace', 'default', 'via', gateway,
+                              'dev', if_remote_name, run_as_root=True)
+            utils.execute('ip', 'netns', 'exec', container_id, 'ip', 'link',
+                          'set', if_remote_name, 'up', run_as_root=True)
+        except Exception:
+            LOG.exception(_("Failed to attach vif"), instance=instance)
 
     def unplug(self, instance, vif):
+        vif_type = vif['type']
+
+        LOG.debug('Unplug vif_type=%(vif_type)s instance=%(instance)s '
+                  'vif=%(vif)s',
+                  {'vif_type': vif_type, 'instance': instance,
+                   'vif': vif})
+
         try:
             self._vrouter_client.delete_port(vif['id'])
         except Exception:
             LOG.exception(_("Delete port failed"), instance=instance)
-
-        if_local_name = 'veth%s' % vif['id'][:8]
-        if_remote_name = 'ns%s' % vif['id'][:8]
-        lease_file = '%s/dhclient.%s.leases' % (self.dhcp_lease_database_dir,
-                                                if_remote_name)
-        utils.execute('ip', 'link', 'delete', if_local_name, run_as_root=True)
-        utils.execute('rm', lease_file, run_as_root=True)


### PR DESCRIPTION
Closes-Bug: #1452151

Using inet6 argument with ip command to configure ipv6 address to container
Closes-Bug: #1455616

Configure network using statically instead of using dhclient to avoid
it writting to the compute hosts resolv.conf
Closes-Bug: #1455168

Periodically check the vrouter agent conncetion and publish the port informaton to
the vrouter agent.
Closes-Bug: #1454655
