### PR TITLE
add active_migrations attribute to DockerDriver

### DIFF
--- a/novadocker/tests/virt/docker/test_driver.py
+++ b/novadocker/tests/virt/docker/test_driver.py
@@ -552,7 +552,7 @@ class DockerDriverTestCase(test_virt_drivers._VirtDriverTestCase,
     def test_get_dns_entries(self):
         driver = docker_driver.DockerDriver(object)
         network_info = utils.get_test_network_info()
-        self.assertEqual(['0.0.0.0', '0.0.0.0'],
+        self.assertEqual(['192.168.122.1', '192.168.122.2'],
                          driver._extract_dns_entries(network_info))
 
     @mock.patch.object(os.path, 'exists', return_value=True)

--- a/novadocker/virt/docker/driver.py
+++ b/novadocker/virt/docker/driver.py
@@ -56,7 +56,7 @@ from novadocker.virt.docker import network
 from novadocker.virt import hostutils
 
 CONF = cfg.CONF
-CONF.import_opt('my_ip', 'nova.netconf')
+CONF.import_opt('my_ip', 'nova.conf.netconf')
 CONF.import_opt('instances_path', 'nova.compute.manager')
 
 docker_opts = [
@@ -113,6 +113,8 @@ class DockerDriver(driver.ComputeDriver):
         self.vif_driver = vif_class()
         self.firewall_driver = firewall.load_driver(
             default='nova.virt.firewall.NoopFirewallDriver')
+        # NOTE(zhangguoqing): For passing the nova unit tests
+        self.active_migrations = {}
 
     @property
     def docker(self):

--- a/novadocker/virt/docker/vifs.py
+++ b/novadocker/virt/docker/vifs.py
@@ -32,7 +32,7 @@ import random
 assert manager
 
 CONF = cfg.CONF
-CONF.import_opt('my_ip', 'nova.netconf')
+CONF.import_opt('my_ip', 'nova.conf.netconf')
 CONF.import_opt('vlan_interface', 'nova.manager')
 CONF.import_opt('flat_interface', 'nova.manager')
 CONF.import_opt('network_device_mtu', 'nova.objects.network')


### PR DESCRIPTION
1. For passing the nova unit tests about the active_migrations attribute.
2. Fix test_get_dns_entries DNS IPs that changed from nova.
3. Add conf path to netconf that changed from nova.

Closes-Bug: #1584741
Closes-Bug: #1582615

Change-Id: Iaab7e695055f042b9060f07e31681c66197b8c79